### PR TITLE
fix :[20230316][이현동] Hashtag 저장까지 해결

### DIFF
--- a/src/main/java/com/jhd/dotime/hashtag/controller/HashTagController.java
+++ b/src/main/java/com/jhd/dotime/hashtag/controller/HashTagController.java
@@ -44,7 +44,7 @@ public class HashTagController {
     @ResponseBody
     @PatchMapping("/hashtag")
     public void createHashTag(@PathVariable Long taskId, @RequestBody HashTagRequestDto hashTagRequestDto){
-        hashTagService.createHashtag(taskId, hashTagRequestDto);
+//        hashTagService.createHashtag(taskId, hashTagRequestDto);
     }
 
     @ApiResponses({

--- a/src/main/java/com/jhd/dotime/hashtag/dto/HashTagRequestDto.java
+++ b/src/main/java/com/jhd/dotime/hashtag/dto/HashTagRequestDto.java
@@ -18,13 +18,10 @@ import javax.persistence.Column;
 public class HashTagRequestDto {
     private String name;
 
-    private String descr;
-
 
     public HashTag toEntity(){
         return HashTag.builder()
                 .name(name)
-                .descr(descr)
                 .build();
     }
 }

--- a/src/main/java/com/jhd/dotime/hashtag/entity/HashTag.java
+++ b/src/main/java/com/jhd/dotime/hashtag/entity/HashTag.java
@@ -22,7 +22,5 @@ public class HashTag extends BaseTimeEntity {
     @Column
     private String name;
 
-    @Column
-    private String descr;
 
 }

--- a/src/main/java/com/jhd/dotime/hashtag/service/HashTagService.java
+++ b/src/main/java/com/jhd/dotime/hashtag/service/HashTagService.java
@@ -4,6 +4,8 @@ package com.jhd.dotime.hashtag.service;
 import com.jhd.dotime.hashtag.dto.HashTagRequestDto;
 import com.jhd.dotime.hashtag.entity.HashTag;
 import com.jhd.dotime.hashtag.repository.HashTagRepository;
+import com.jhd.dotime.tasks.dto.TaskSaveRequestDto;
+import com.jhd.dotime.tasks.entity.Task;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,6 +13,8 @@ import java.util.List;
 public interface HashTagService {
 
     List<HashTag> getHashTagList();
-    Long createHashtag(Long taskId, HashTagRequestDto hashTagRequestDto);
+//    Long createHashtag(Long taskId, HashTagRequestDto hashTagRequestDto);
+
+    void createHashtag(String hashtag);
 
 }

--- a/src/main/java/com/jhd/dotime/hashtag/service/HashTagServiceImpl.java
+++ b/src/main/java/com/jhd/dotime/hashtag/service/HashTagServiceImpl.java
@@ -12,6 +12,7 @@ import com.jhd.dotime.members.entity.Member;
 import com.jhd.dotime.members.repository.MemberRepository;
 import com.jhd.dotime.tasks.common.error.TaskErrorCode;
 import com.jhd.dotime.tasks.common.exception.TaskException;
+import com.jhd.dotime.tasks.dto.TaskSaveRequestDto;
 import com.jhd.dotime.tasks.entity.Task;
 import com.jhd.dotime.tasks.repository.TaskRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -39,12 +42,20 @@ public class HashTagServiceImpl implements HashTagService {
 
     @Override
     @Transactional
-    public Long createHashtag(Long taskId, HashTagRequestDto hashTagRequestDto) {
-        Task task = taskRepository.findById(taskId).orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUNT));
-        TaskTag newTaskTag = TaskTag.builder().task(task).hashTag(hashTagRequestDto.toEntity()).build();
-        taskTagRepository.save(newTaskTag);
+    public void createHashtag(String hashtag) {
+//        Task task = taskRepository.findById(taskId).orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUNT));
+//        TaskTag newTaskTag = TaskTag.builder().task(task).hashTag(hashTagRequestDto.toEntity()).build();
+//        taskTagRepository.save(newTaskTag);
+        String pat = "#(\\S+)";
+        Pattern pattern = Pattern.compile(pat);
+        Matcher res = pattern.matcher(hashtag);
 
-        return newTaskTag.getId();
+        while(res.find()){
+//            System.out.println("res.group() = " + res.group(1));
+            HashTag newTag = HashTag.builder().name(res.group(1)).build();
+            hashTagRepository.save(newTag);
+        }
+
 
     }
 }


### PR DESCRIPTION
- 현재 Hashtag는 Task 저장 시 저장하도록 구현되어 있는데, 문제는 TaskTag에 TaskId도 함께 저장해야 하기 때문에 여기서 시점의 문제가 있다. 우선 Hashtag를 먼저 저장하고 findByname으로 Hashtag를 조회하여 TaskId와 HashTagId를 TaskTag 테이블에 저장하도록 구현하자..